### PR TITLE
Implement image validation for recipe and user profile pictures with …

### DIFF
--- a/recipe_manager_api/app/controllers/recipes_controller.rb
+++ b/recipe_manager_api/app/controllers/recipes_controller.rb
@@ -35,10 +35,10 @@ class RecipesController < ApplicationController
   end
 
   def update
-      if @recipe.update(recipe_params)
-        if params[:picture].present?
-          @recipe.picture.attach(params[:picture])
-        end
+      @recipe.assign_attributes(recipe_params)
+      @recipe.picture.attach(params[:picture]) if params[:picture].present?
+
+      if @recipe.save
         render json: RecipeBlueprint.render(@recipe, view: :normal)
       else
         render json: { errors: @recipe.errors.full_messages }, status: :unprocessable_entity

--- a/recipe_manager_api/app/controllers/users_controller.rb
+++ b/recipe_manager_api/app/controllers/users_controller.rb
@@ -22,10 +22,10 @@ class UsersController < ApplicationController
 
   def update
     @user = User.find(params[:id])
-      if @user.update(user_params)
-        if params[:profile_picture].present?
-          @user.profile_picture.attach(params[:profile_picture])
-        end
+      @user.assign_attributes(user_params)
+      @user.profile_picture.attach(params[:profile_picture]) if params[:profile_picture].present?
+
+      if @user.save
         render json: UserBlueprint.render(@user, view: :normal), status: :ok
       else
         render json: { errors: @user.errors.full_messages }, status: :unprocessable_entity

--- a/recipe_manager_api/app/models/recipe.rb
+++ b/recipe_manager_api/app/models/recipe.rb
@@ -6,6 +6,8 @@ class Recipe < ApplicationRecord
             presence: true,
             numericality: { only_integer: true, greater_than_or_equal_to: 0, less_than_or_equal_to: 999 }
   validates :description, length: { maximum: 1000, too_long: "%{count} characters is the maximum allowed" }, allow_blank: true
+  # image validation
+  validate :acceptable_picture
 
   # associations
   belongs_to :user
@@ -20,4 +22,22 @@ class Recipe < ApplicationRecord
   accepts_nested_attributes_for :label
   # also added recipe pictures via active storage: same as user profile pictures
   has_one_attached :picture
+
+  # --finally-- implementing file type restrictions to most common image formats
+  ALLOWED_IMAGE_CONTENT_TYPES = %w(image/jpeg image/png image/webp).freeze
+  MAX_IMAGE_BYTES = 5.megabytes
+
+  private
+
+  def acceptable_picture
+    return unless picture.attached?
+
+    unless picture.content_type.in?(ALLOWED_IMAGE_CONTENT_TYPES)
+      errors.add(:picture, "must be a JPEG, PNG, or WebP image")
+    end
+
+    if picture.byte_size > MAX_IMAGE_BYTES
+      errors.add(:picture, "is too large (max 5 MB)")
+    end
+  end
 end

--- a/recipe_manager_api/app/models/user.rb
+++ b/recipe_manager_api/app/models/user.rb
@@ -9,9 +9,27 @@ class User < ApplicationRecord
 
   validates :first_name, :last_name, presence: true, length: { maximum: 255, too_long: "%{count} characters is the maximum allowed" }
   validates :preferred_system, presence: true, inclusion: { in: %w(metric imperial) }
-
+  validate :acceptable_profile_picture
   # associations
   has_many :recipes, dependent: :destroy
   # using active storage for pictures after all: it's well-supported for small-scale use, allegedly.
   has_one_attached :profile_picture
+
+  # --finally-- implementing file type restrictions to most common image formats
+  ALLOWED_IMAGE_CONTENT_TYPES = %w(image/jpeg image/png image/webp).freeze
+  MAX_IMAGE_BYTES = 5.megabytes
+
+  private
+
+  def acceptable_profile_picture
+    return unless profile_picture.attached?
+
+    unless profile_picture.content_type.in?(ALLOWED_IMAGE_CONTENT_TYPES)
+      errors.add(:profile_picture, "must be a JPEG, PNG, or WebP image")
+    end
+
+    if profile_picture.byte_size > MAX_IMAGE_BYTES
+      errors.add(:profile_picture, "is too large (max 5 MB)")
+    end
+  end
 end


### PR DESCRIPTION
…file type restrictions and size limits:

Added has_one_attached validations via custom acceptable_picture methods (allow jpeg, png, webp, 5MB max).